### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Excel2json is a converting script that supports to manage well structured excel 
 
 You can freely redistribute this product with A-CUP-OF-BEER License (See source code)
 
-#USAGE#
+# USAGE #
 
 ## ADD SOME HINTS TO YOUR EXCEL FILE FOR JSON ##
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
